### PR TITLE
Removed dependency on jQuery, refactored DOM event handlers

### DIFF
--- a/starter-code/index.html
+++ b/starter-code/index.html
@@ -5,9 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <link rel="stylesheet" href="./public/stylesheets/style.css">
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
   <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
-
   <title>IH Characters</title>
 </head>
 <body>

--- a/starter-code/public/javascript/index.js
+++ b/starter-code/public/javascript/index.js
@@ -1,23 +1,23 @@
-const charactersAPI = new APIHandler("http://localhost:8000")
+const charactersAPI = new APIHandler('http://localhost:8000');
 
-$(document).ready( () => {
-  document.getElementById('fetch-all').onclick = function(){
+window.addEventListener('load', () => {
+  document.getElementById('fetch-all').addEventListener('click', function (event) {
 
-  }
-  
-  document.getElementById('fetch-one').onclick = function(){
-    
-  }
-  
-  document.getElementById('delete-one').onclick = function(){
-        
-  }
-  
-  document.getElementById('edit-character-form').onsubmit = function(){
-            
-  }
-  
-  document.getElementById('new-character-form').onsubmit = function(){
-                
-  }
-})
+  });
+
+  document.getElementById('fetch-one').addEventListener('click', function (event) {
+
+  });
+
+  document.getElementById('delete-one').addEventListener('click', function (event) {
+
+  });
+
+  document.getElementById('edit-character-form').addEventListener('submit', function (event) {
+
+  });
+
+  document.getElementById('new-character-form').addEventListener('submit', function (event) {
+
+  });
+});


### PR DESCRIPTION
Refactored main script to remove dependency on jQuery when listening to page load event.

Refactored DOM event handlers to use addEventListener instead of onclick and onsubmit properties, since the second option, although less verbose, has some limitations (addEventListener allows us to have multiple listeners for the same event, while we can't have multiple onclick properties).

Removed import of jQuery from index.html.

@sandrabosk 